### PR TITLE
Remove comments from settings file before parsing json

### DIFF
--- a/linterSettings.js
+++ b/linterSettings.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
         .done(function( fileReader ) {
             fileReader.read().done(function (text) {
                 try {
-                    linter.settings = JSON.parse(text);
+                    linter.settings = JSON.parse(stripComments(text));
                 }
                 catch( ex ) {
                     Dialogs.showModalDialog(
@@ -64,6 +64,18 @@ define(function (require, exports, module) {
     function register( linter ) {
         linters[linter.name] = linter;
         loadProjectSettings( linter );
+    }
+
+    /**
+     * Strips all commments from a json string.
+     */
+    function stripComments( text ) {
+        var string = text || '';
+
+        string = string.replace(/\/\*(?:[^\*\/])*\*\//g, '');
+        string = string.replace(/\/\/.*/g, '');
+
+        return string;
     }
 
 


### PR DESCRIPTION
I had a problem with loading my .jshintrc files from my project as they contain comments for documenting
the various settings.
Unfortunately the JSON.parse does not support comments in JSON strings.
This might be okay for normal JSON objects, but I think some jshint configuration parameters are not as descriptive that everybody understands it intention.
So I've implemented a little filter function  to remove all comments from the settings file before parsing it.
