### PR TITLE
Move registering keybinds & commands out of lint() function.

### DIFF
--- a/linterManager.js
+++ b/linterManager.js
@@ -21,8 +21,6 @@ define(function (require /*, exports, module*/) {
             _timer    = null,
             _mode     = "",
             _fullPath = "";
-        
-        linterReporter.registerKeyBindings();
 
         function lint( ) {
             if ( !_cm || !languages[_mode] ) {
@@ -106,11 +104,15 @@ define(function (require /*, exports, module*/) {
             });
         }
 
+        function registerKeyBindings() {
+            linterReporter.registerKeyBindings();
+        }
 
         return {
             lint: lint,
             register: register,
-            setDocument: setDocument
+            setDocument: setDocument,
+            registerKeyBindings: registerKeyBindings
         };
 
     })();

--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ define(function (require, exports, module) {
         }
     }
 
+    linterManager.registerKeyBindings();
+
     AppInit.appReady(function(){
         pluginManager().done(function(plugins) {
             for ( var iPlugin in plugins ) {


### PR DESCRIPTION
Moves registering keybinds & commands out of `lint()` function. Followup on #40.
