### PR TITLE
Remove registering of noop linters

### DIFF
--- a/linterManager.js
+++ b/linterManager.js
@@ -8,8 +8,7 @@
 define(function (require /*, exports, module*/) {
     'use strict';
 
-    var CodeInspection = brackets.getModule("language/CodeInspection"),
-        CodeMirror     = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror     = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
         linterSettings = require("linterSettings"),
         linterReporter = require("linterReporter"),
         languages      = {},
@@ -93,15 +92,6 @@ define(function (require /*, exports, module*/) {
         function register( linter ) {
             languages[linter.language] = linter;
             linters[linter.name] = linter;
-
-            //
-            // Make sure we override the default linters because doing double processing
-            // is extremely expensive
-            //
-            /*CodeInspection.register(linter.language, {
-                name: linter.language,
-                scanFile: $.noop
-            });*/
         }
 
         function registerKeyBindings() {


### PR DESCRIPTION
This change makes Brackets not report errors for lints/tests registered with the same name.

Fix #39, but in a roundabout (and seemingly "bad" way). The reason that I've commented out the code - and not removed it - is because this code seems to be a good idea. Yet, as far as I can tell from [`CodeInspection#register`](https://github.com/adobe/brackets/blob/master/src/language/CodeInspection.js#L453), this code is useless: it does not accomplish the task of preventing double processing. The only instance it would do so is with a JSLint linter named `jslint` (and not any other linter).

Here's the [`CodeInspection#register`](https://github.com/adobe/brackets/blob/master/src/language/CodeInspection.js#L453) method:

``` javascript
/**
 * The provider is passed the text of the file and its fullPath. Providers should not assume
 * that the file is open (i.e. DocumentManager.getOpenDocumentForPath() may return null) or
 * that the file on disk matches the text given (file may have unsaved changes).
 * 
 * Registering any provider for the "javascript" language automatically unregisters the built-in
 * Brackets JSLint provider. This is a temporary convenience until UI exists for disabling
 * registered providers.
 * 
 * Providers implement scanFile() if results are available synchronously, or scanFileAsync() if results
 * may require an async wait (if both are implemented, scanFile() is ignored). scanFileAsync() returns
 * a {$.Promise} object resolved with the same type of value as scanFile() is expected to return.
 * Rejecting the promise is treated as an internal error in the provider.
 * 
 * @param {string} languageId
 * @param {{name:string, scanFileAsync:?function(string, string):!{$.Promise},
 *         scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}} provider
 *
 * Each error is: { pos:{line,ch}, endPos:?{line,ch}, message:string, type:?Type }
 * If type is unspecified, Type.WARNING is assumed.
 * If no errors found, return either null or an object with a zero-length `errors` array.
 */
 function register(languageId, provider) {
        if (!_providers[languageId]) {
            _providers[languageId] = [];
        }

        if (languageId === "javascript") {
            // This is a special case to enable extension provider to replace the JSLint provider
            // in favor of their own implementation
            _.remove(_providers[languageId], function (registeredProvider) {
                return registeredProvider.name === "JSLint";
            });
        }

        _providers[languageId].push(provider);

        run();  // in case a file of this type is open currently
  }
```
