### PR TITLE
Display details URL in tooltip.

### DIFF
--- a/templates/inlineWidgetLint.html
+++ b/templates/inlineWidgetLint.html
@@ -2,7 +2,7 @@
     {{#messages}}
         <div class="interactive-linter-line-{{type}} interactive-linter-line-{{code}}">
             {{reason}}
-            {{#href}} - <a href="{{href}}" titlee="{{href}}">Details</a>{{/href}}
+            {{#href}} - <a href="{{href}}" title="{{href}}">Details</a>{{/href}}
         </div>
     {{/messages}}
 </div>


### PR DESCRIPTION
Added because the user should know where the link will lead them if external.

This is somewhat of a controversial change, since Brackets does not display the URL on links be default, but I think it will help users safety of mind and improve their overall experience.
