### PR TITLE
Remove scope from JSHINT messages to prevent #80.

### DIFF
--- a/plugins/jshint/main.js
+++ b/plugins/jshint/main.js
@@ -37,6 +37,7 @@ define(function(require /*, exports, module*/) {
                 // means that the max number of errors was exceeded or there was a fatal
                 // error while linting the file
                 if (errors[i]) {
+                    delete errors[i].scope; // Some errors have scope, which breaks workers (cannot clone objects)
                     errors[i].token = groomer.groom(errors[i], settings);
                 }
             }


### PR DESCRIPTION
Fixes #80.

@MiguelCastillo Are there any side effects to removing scope? Do we use it anywhere?
