### PR TITLE
Fixes bug where keyboard shortcut is called in a file with no linters.

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,9 @@ define(function (require, exports, module) {
 
 
     function handleToggleLineDetails() {
-        currentLinter.reporter.toggleLineDetails();
+        if (currentLinter) {
+            currentLinter.reporter.toggleLineDetails();
+        }
     }
 
 


### PR DESCRIPTION
Fixes a bug I introduced, to test press "Ctrl-Shift-E" in an HTML file, which currently has no linters from Interactive Linter.
