### PR TITLE
Standardize "use strict".

### DIFF
--- a/lintIndicator.js
+++ b/lintIndicator.js
@@ -1,5 +1,5 @@
 define(function (require/*, exports, module*/) {
-    'use strict';
+    "use strict";
 
     var DefaultDialogs   = brackets.getModule("widgets/DefaultDialogs"),
         Dialogs          = brackets.getModule("widgets/Dialogs"),

--- a/lintPanel.js
+++ b/lintPanel.js
@@ -1,4 +1,6 @@
 define(function (require, exports, module) {
+    "use strict";
+
     var EditorManager    = brackets.getModule("editor/EditorManager"),
         MainViewManager  = brackets.getModule("view/MainViewManager"),
         WorkspaceManager = brackets.getModule("view/WorkspaceManager"),

--- a/linterReporter.js
+++ b/linterReporter.js
@@ -6,7 +6,7 @@
 
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
     var spromise = require("libs/js/spromise");
 

--- a/linterSettings.js
+++ b/linterSettings.js
@@ -6,7 +6,7 @@
 
 
 define(function (require/*, exports, module*/) {
-    'use strict';
+    "use strict";
 
     var Dialogs         = brackets.getModule("widgets/Dialogs"),
         ProjectManager  = brackets.getModule("project/ProjectManager"),

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@
 
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
     // Reference for jshint errors/warnings
     // http://jslinterrors.com

--- a/pluginManager.js
+++ b/pluginManager.js
@@ -6,7 +6,7 @@
 
 
 define(function(require, exports, module) {
-    'use strict';
+    "use strict";
 
     var FileSystem   = brackets.getModule("filesystem/FileSystem");
     var pluginLoader = require("pluginLoader");

--- a/plugins/jscs/groomer.js
+++ b/plugins/jscs/groomer.js
@@ -23,7 +23,7 @@
  */
 
 define(function (require, exports, module) {
-	'use strict';
+	"use strict";
 
 	/**
 	 * Breaks up the message from jshint into something that can be used

--- a/plugins/jshint/groomer.js
+++ b/plugins/jshint/groomer.js
@@ -25,7 +25,7 @@
 /*jslint plusplus: true, nomen: true, regexp: true, maxerr: 50 */
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
     /**
     * Used for reporting errors.  The name is shorter to more directly match

--- a/plugins/jslint/groomer.js
+++ b/plugins/jslint/groomer.js
@@ -24,7 +24,7 @@
 
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
     var JSLintError = require('jslint/libs/JSLintError');
 

--- a/plugins/jsonlint/groomer.js
+++ b/plugins/jsonlint/groomer.js
@@ -6,7 +6,7 @@
 
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
     /**
      * Breaks up the message from jshint into something that can be used


### PR DESCRIPTION
All modules should have a "use strict"; at the top of the file.

Part of the CodeInspection PR, but since I want to minimize that PR to just CodeInspection related changes, thought I would open this up and then just rebase off of master at some point; squashing commits along the way.
