### PR TITLE
Refactor inline widget code into it's own file/class: ProblemWidget.

### DIFF
--- a/ProblemWidget.js
+++ b/ProblemWidget.js
@@ -1,0 +1,53 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    var InlineWidget = brackets.getModule("editor/InlineWidget").InlineWidget;
+
+    var widgetTemplate = require("text!templates/inlineWidgetLint.html");
+
+    function ProblemWidget(mark, line) {
+        InlineWidget.call(this);
+
+        var problems = [].concat(mark.warnings, mark.errors);
+
+        var $html = $(Mustache.render(widgetTemplate, { messages: problems }));
+
+        this.$wrapperDiv = $html;
+        this.$htmlContent.append(this.$wrapperDiv);
+
+        this.$wrapperDiv.on("mousedown", function (e) {
+            e.stopPropagation();
+        });
+
+        this.line = line;
+
+        this._sizeEditorToContent   = this._sizeEditorToContent.bind(this);
+    }
+
+    ProblemWidget.prototype = Object.create(InlineWidget.prototype);
+    ProblemWidget.prototype.constructor = ProblemWidget;
+    ProblemWidget.prototype.parentClass = InlineWidget.prototype;
+
+    ProblemWidget.prototype.$wrapperDiv = null;
+    ProblemWidget.prototype.$scroller = null;
+
+    ProblemWidget.prototype.onAdded = function () {
+        ProblemWidget.prototype.parentClass.onAdded.apply(this, arguments);
+
+        // Set height initially, and again whenever width might have changed (word wrap)
+        this._sizeEditorToContent();
+        $(window).on("resize", this._sizeEditorToContent);
+    };
+
+    ProblemWidget.prototype.onClosed = function () {
+        ProblemWidget.prototype.parentClass.onClosed.apply(this, arguments);
+
+        $(window).off("resize", this._sizeEditorToContent);
+    };
+
+    ProblemWidget.prototype._sizeEditorToContent = function () {
+        this.hostEditor.setInlineWidgetHeight(this, this.$wrapperDiv.height() + 20, true);
+    };
+
+    module.exports = ProblemWidget;
+});

--- a/ProblemWidget.js
+++ b/ProblemWidget.js
@@ -28,9 +28,6 @@ define(function (require, exports, module) {
     ProblemWidget.prototype.constructor = ProblemWidget;
     ProblemWidget.prototype.parentClass = InlineWidget.prototype;
 
-    ProblemWidget.prototype.$wrapperDiv = null;
-    ProblemWidget.prototype.$scroller = null;
-
     ProblemWidget.prototype.onAdded = function () {
         ProblemWidget.prototype.parentClass.onAdded.apply(this, arguments);
 

--- a/linterReporter.js
+++ b/linterReporter.js
@@ -170,15 +170,13 @@ define(function (require, exports, module) {
 
         var mark = this.marks[cursorPos.line];
 
-        if (!mark) {
-            return;
+        if (mark) {
+            var problemWidget = new ProblemWidget(mark, cursorPos.line);
+            problemWidget.load(activeEditor);
+            activeEditor.addInlineWidget(cursorPos, problemWidget, true);
+
+            mark.inlineWidget = problemWidget;
         }
-
-        var problemWidget = new ProblemWidget(mark, cursorPos.line);
-        problemWidget.load(activeEditor);
-        activeEditor.addInlineWidget(cursorPos, problemWidget, true);
-
-        mark.inlineWidget = problemWidget;
     };
 
     /**

--- a/linterReporter.js
+++ b/linterReporter.js
@@ -8,13 +8,11 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var spromise = require("libs/js/spromise");
+    var spromise = require("libs/js/spromise"),
+        ProblemWidget = require("ProblemWidget");
 
     var EditorManager     = brackets.getModule("editor/EditorManager"),
-        InlineWidget      = brackets.getModule("editor/InlineWidget").InlineWidget,
         _                 = brackets.getModule("thirdparty/lodash");
-
-    var inlineWidgetLintTemplate = require("text!templates/inlineWidgetLint.html");
 
 
     function Reporter() {
@@ -118,7 +116,7 @@ define(function (require, exports, module) {
         this.cm.clearGutter("interactive-linter-gutter");
 
         _.forEach(this.marks, function (mark) {
-            _.forEach(mark.lineMarks, function (textMark) {
+            mark.lineMarks.forEach(function (textMark) {
                 textMark.line.clear();
             });
 
@@ -142,14 +140,14 @@ define(function (require, exports, module) {
         var inlineWidgets = activeEditor.getInlineWidgets();
 
         return _.find(inlineWidgets, function (widget) {
-            return widget.interactiveLinterLineNumber === line;
+            return widget instanceof ProblemWidget && widget.line === line;
         });
     };
 
 
     Reporter.prototype.toggleLineDetails = function (line) {
         var activeEditor = EditorManager.getActiveEditor();
-        var cursorPos    = line !== undefined ? {line: line, ch: 0} : activeEditor.getCursorPos();
+        var cursorPos    = line === undefined ? activeEditor.getCursorPos() : { line: line, ch: 0 };
         var lineWidget   = this.getWidgetForLine(cursorPos.line);
 
         if (lineWidget) {
@@ -176,33 +174,12 @@ define(function (require, exports, module) {
             return;
         }
 
-        var inlineWidget = new InlineWidget();
-        mark.inlineWidget = inlineWidget;
-        inlineWidget.load(EditorManager.getActiveEditor());
-        inlineWidget.interactiveLinterLineNumber = cursorPos.line;
-        activeEditor.addInlineWidget(cursorPos, inlineWidget, true);
+        var problemWidget = new ProblemWidget(mark, cursorPos.line);
+        problemWidget.load(activeEditor);
+        activeEditor.addInlineWidget(cursorPos, problemWidget, true);
 
-        this.updateLineDetails(mark);
+        mark.inlineWidget = problemWidget;
     };
-
-
-    Reporter.prototype.updateLineDetails = function (mark) {
-        var activeEditor = EditorManager.getActiveEditor();
-        var inlineWidget = mark.inlineWidget;
-
-        var messages = [].concat(mark.errors, mark.warnings);
-
-        var $errorHtml = $(Mustache.render(inlineWidgetLintTemplate, {messages: messages}));
-
-        inlineWidget.$htmlContent.append($errorHtml);
-
-        $errorHtml.on("mousedown", function (e) {
-            e.stopPropagation();
-        });
-
-        activeEditor.setInlineWidgetHeight(inlineWidget, $errorHtml.height() + 20);
-    };
-
 
     /**
      * Determines if there is a fatal error in the linting report


### PR DESCRIPTION
@MiguelCastillo Please review -- for a Brackets source code example, see https://github.com/adobe/brackets/blob/master/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js.