### PR TITLE
Fix status icon for HTMLHint and CSSLint when there are no problems.

### DIFF
--- a/plugins/default/csslint/main.js
+++ b/plugins/default/csslint/main.js
@@ -17,10 +17,13 @@ define(function(require) {
     function lint(text, options) {
         options = utils.mixin({}, defaultOptions, options);
         var results = CSSLint.verify(text, options).messages;
-        var i, length;
 
-        for (i = 0, length = results.length; i < length; i++) {
-            delete results[i].rule;
+        var length = results.length;
+        if (length == 0) {
+            return;
+        }
+        var i;
+        for (i = 0; i < length; i++) {
             groomer.groom(results[i]);
         }
 

--- a/plugins/default/htmlhint/main.js
+++ b/plugins/default/htmlhint/main.js
@@ -18,8 +18,12 @@ define(function(require) {
         options = utils.mixin({}, defaultOptions, options);
         var results = HTMLHint.verify(text, options);
 
-        var i, length;
-        for (i = 0, length = results.length; i < length; i++) {
+        var length = results.length;
+        if (length == 0) {
+            return;
+        }
+        var i;
+        for (i = 0; i < length; i++) {
             groomer.groom(results[i]);
         }
 


### PR DESCRIPTION
The HTMLHint and CSSLint main functions return a 0-length array when there are no problems. This causes the status icon to show the yellow "warning" sign, but the tooltip to indicate that there are 0 problems.

![brackets-interactivelinter-warning-0-problems](https://cloud.githubusercontent.com/assets/1463364/7422686/b18bee7e-ef5c-11e4-9701-e6788f158894.png)

I added checks for this condition to both plugins.