### PR TITLE
add default results value to prevent crash when accessing array items

### DIFF
--- a/plugins/default/eslint/main.js
+++ b/plugins/default/eslint/main.js
@@ -16,7 +16,7 @@ define(function(require /*, exports, module*/) {
 
     function lint(source, options) {
         options = utils.mixin({}, defaultOptions, options);
-        var results, i, length;
+        var results = [], i, length;
 
         try {
             results = eslint.verify(source, options);


### PR DESCRIPTION
https://github.com/MiguelCastillo/Brackets-InteractiveLinter/issues/129