### PR TITLE
Jslint website update

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Interactive Linter automatically loads `.jshintrc` and `.jslintrc` files in your
 
 All JSHint settings that already exists inline in your JavaScript files will continue to work along side any `.jshintrc`/`.jslintrc` file.
 
-Integration with <http://jslinterrors.com/> to find out details about what's reported by JSHint.
+Integration with <http://linterrors.com/> to find out details about what's reported by JSHint.
 
 Inspired by Joachim's extensions [brackets-continuous-compilation](https://github.com/JoachimK/brackets-continuous-compilation).
 

--- a/plugins/default/threaded/jshint/groomer.js
+++ b/plugins/default/threaded/jshint/groomer.js
@@ -194,7 +194,7 @@ define(function(/*require, exports, module*/) {
 
 
         // Add href for help
-        message.href    = "http://jslinterrors.com/" + (message.raw || "").replace(/'*\{*(\w*)\}*'*/g, "$1").replace(/\s/g, "-").replace(/\.$/, "").toLowerCase();
+		message.href    = "http://linterrors.com/js?q="+message.code;
         message.message = message.reason + " - " + message.code;
         message.token   = token;
 


### PR DESCRIPTION
Heres a update for the lint errors link that went down

I only updated the JSHint plugin - I'm not sure the JSLint one has a "code" property but it looks like http://linterrors.com/ could be used for that one as well